### PR TITLE
feat: add skip to next song (spotify)

### DIFF
--- a/pages/app/setup.vue
+++ b/pages/app/setup.vue
@@ -2,12 +2,22 @@
 definePageMeta({ layout: "app", middleware: "session" });
 
 const { data: service } = await useFetch("/api/twitch/rewards/spotify-sr");
+const { data: service2 } = await useFetch("/api/twitch/rewards/spotify-skip");
 
 const webhook = ref(service.value?.rewards ? service.value?.rewards[0] : null);
+const webhook2 = ref(service2.value?.rewards ? service2.value?.rewards[0] : null);
+
 const loading = ref(false);
 const { $toasts } = useNuxtApp();
 
-const { form, formReset } = useFormState({
+const { form: formSr, formReset: formResetSr } = useFormState({
+  title: "",
+  description: "",
+  cost: null as number | null,
+  color: "#1ED760"
+});
+
+const { form: formSkip, formReset: formResetSkip } = useFormState({
   title: "",
   description: "",
   cost: null as number | null,
@@ -15,17 +25,24 @@ const { form, formReset } = useFormState({
 });
 
 if (webhook.value) {
-  form.value.title = webhook.value.reward.title;
-  form.value.description = webhook.value.reward.description;
-  form.value.cost = webhook.value.reward.cost;
-  form.value.color = webhook.value.reward.color;
+  formSr.value.title = webhook.value.reward.title;
+  formSr.value.description = webhook.value.reward.description;
+  formSr.value.cost = webhook.value.reward.cost;
+  formSr.value.color = webhook.value.reward.color;
+}
+
+if (webhook2.value) {
+  formSkip.value.title = webhook2.value.reward.title;
+  formSkip.value.description = webhook2.value.reward.description;
+  formSkip.value.cost = webhook2.value.reward.cost;
+  formSkip.value.color = webhook2.value.reward.color;
 }
 
 const createReward = async () => {
   loading.value = true;
   const newWebhook = await $fetch("/api/twitch/rewards/spotify-sr", {
     method: "POST",
-    body: form.value
+    body: formSr.value
   }).catch(() => null);
   loading.value = false;
 
@@ -36,10 +53,33 @@ const createReward = async () => {
     transport: newWebhook.data[0].transport,
     reward: {
       id: newWebhook.data[0].condition.reward_id,
-      title: form.value.title,
-      description: form.value.description,
-      cost: Number(form.value.cost),
-      color: form.value.color
+      title: formSr.value.title,
+      description: formSr.value.description,
+      cost: Number(formSr.value.cost),
+      color: formSr.value.color
+    }
+  };
+};
+
+const createReward2 = async () => {
+  loading.value = true;
+  const newWebhook = await $fetch("/api/twitch/rewards/spotify-skip", {
+    method: "POST",
+    body: formSkip.value
+  }).catch(() => null);
+  loading.value = false;
+
+  if (!newWebhook) return;
+  $toasts.add({ message: "Reward added to your Twitch channel", success: true });
+  webhook2.value = {
+    id: newWebhook.data[0].id,
+    transport: newWebhook.data[0].transport,
+    reward: {
+      id: newWebhook.data[0].condition.reward_id,
+      title: formSkip.value.title,
+      description: formSkip.value.description,
+      cost: Number(formSkip.value.cost),
+      color: formSkip.value.color
     }
   };
 };
@@ -52,16 +92,28 @@ const deleteReward = async (id_webhook: string, id_reward: string) => {
   loading.value = false;
   if (!remove) return;
   $toasts.add({ message: "Reward deleted from your Twitch channel", success: true });
-  formReset();
+  formResetSr();
   webhook.value = null;
+};
+
+const deleteReward2 = async (id_webhook: string, id_reward: string) => {
+  loading.value = true;
+  const remove = await $fetch(`/api/twitch/rewards/spotify-skip?id_webhook=${id_webhook}&id_reward=${id_reward}`, {
+    method: "DELETE"
+  }).catch(() => null);
+  loading.value = false;
+  if (!remove) return;
+  $toasts.add({ message: "Reward deleted from your Twitch channel", success: true });
+  formResetSkip();
+  webhook2.value = null;
 };
 </script>
 
 <template>
   <main class="py-4">
     <h1 class="mb-4">Setup</h1>
-    <div class="row flex-gap-1">
-      <div class="col-lg-12">
+    <div class="row flex-gap-4 gy-4">
+      <div class="col-lg-6">
         <div class="rounded-4 p-4 bg-body-secondary border border-2 position-relative">
           <form @submit.prevent="webhook ? deleteReward(webhook.id, webhook.reward.id) : createReward()">
             <div :class="`d-flex gap-1 justify-content-center align-items-center position-absolute top-0 end-0 m-2 px-3 py-1 rounded-4 small text-body-emphasis ${webhook ? 'bg-success' : 'bg-secondary'}`">
@@ -74,26 +126,26 @@ const deleteReward = async (id_webhook: string, id_reward: string) => {
               <h2 class="m-0">Spotify SR</h2>
             </div>
             <div class="form-floating mb-2">
-              <InputLeft max="45" :text="form.title" class="position-absolute top-0 end-0 px-2 pt-1" />
-              <input id="title" v-model="form.title" type="text" class="form-control" placeholder="Title" maxlength="45" required>
+              <InputLeft max="45" :text="formSr.title" class="position-absolute top-0 end-0 px-2 pt-1" />
+              <input id="title" v-model="formSr.title" type="text" class="form-control" placeholder="Title" maxlength="45" required>
               <label for="client">Title</label>
             </div>
             <div class="form-floating mb-2">
-              <InputLeft max="200" :text="form.description" class="position-absolute top-0 end-0 px-2 pt-1" />
-              <textarea id="description" v-model="form.description" type="text" class="form-control" placeholder="Description" maxlength="200" style="height: 150px;" />
+              <InputLeft max="200" :text="formSr.description" class="position-absolute top-0 end-0 px-2 pt-1" />
+              <textarea id="description" v-model="formSr.description" type="text" class="form-control" placeholder="Description" maxlength="200" style="height: 150px;" />
               <label for="client">Description</label>
             </div>
             <div class="input-group mb-2">
-              <span class="input-group-text text-body-emphasis" :style="{ backgroundColor: form.color }">
+              <span class="input-group-text text-body-emphasis" :style="{ backgroundColor: formSr.color }">
                 <IconsReward size="1.4rem" />
               </span>
               <div class="form-floating">
-                <input id="cost" v-model="form.cost" type="number" class="form-control" placeholder="Cost" required>
+                <input id="cost" v-model="formSr.cost" type="number" class="form-control" placeholder="Cost" required>
                 <label for="cost">Cost</label>
               </div>
             </div>
             <div class="mb-2 d-flex gap-2 align-items-center">
-              <input id="color" v-model="form.color" type="color" class="form-control form-control-color" title="Choose your color">
+              <input id="color" v-model="formSr.color" type="color" class="form-control form-control-color" title="Choose your color">
               <label for="color">Background color</label>
             </div>
             <div v-if="!service?.connected" class="alert alert-dark d-flex align-items-center" role="alert">
@@ -105,6 +157,56 @@ const deleteReward = async (id_webhook: string, id_reward: string) => {
                 <Transition name="slide" mode="out-in">
                   <SpinnerCircle v-if="loading" />
                   <span v-else>{{ webhook ? 'Delete reward' : 'Create reward' }}</span>
+                </Transition>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="rounded-4 p-4 bg-body-secondary border border-2 position-relative">
+          <form @submit.prevent="webhook2 ? deleteReward2(webhook2.id, webhook2.reward.id) : createReward2()">
+            <div :class="`d-flex gap-1 justify-content-center align-items-center position-absolute top-0 end-0 m-2 px-3 py-1 rounded-4 small text-body-emphasis ${webhook2 ? 'bg-success' : 'bg-secondary'}`">
+              <Icon name="solar:record-bold-duotone" size="1.2rem" />
+              <span v-if="webhook2" class="d-none d-lg-block">Created</span>
+              <span v-else class="d-none d-lg-block">Not created</span>
+            </div>
+            <div class="d-flex gap-2 justify-content-center align-items-center mb-3">
+              <Icon name="bi:twitch" size="2em" />
+              <h2 class="m-0">Spotify Skip To Next Song</h2>
+            </div>
+            <div class="form-floating mb-2">
+              <InputLeft max="45" :text="formSkip.title" class="position-absolute top-0 end-0 px-2 pt-1" />
+              <input id="title" v-model="formSkip.title" type="text" class="form-control" placeholder="Title" maxlength="45" required>
+              <label for="client">Title</label>
+            </div>
+            <div class="form-floating mb-2">
+              <InputLeft max="200" :text="formSkip.description" class="position-absolute top-0 end-0 px-2 pt-1" />
+              <textarea id="description" v-model="formSkip.description" type="text" class="form-control" placeholder="Description" maxlength="200" style="height: 150px;" />
+              <label for="client">Description</label>
+            </div>
+            <div class="input-group mb-2">
+              <span class="input-group-text text-body-emphasis" :style="{ backgroundColor: formSkip.color }">
+                <IconsReward size="1.4rem" />
+              </span>
+              <div class="form-floating">
+                <input id="cost" v-model="formSkip.cost" type="number" class="form-control" placeholder="Cost" required>
+                <label for="cost">Cost</label>
+              </div>
+            </div>
+            <div class="mb-2 d-flex gap-2 align-items-center">
+              <input id="color" v-model="formSkip.color" type="color" class="form-control form-control-color" title="Choose your color">
+              <label for="color">Background color</label>
+            </div>
+            <div v-if="!service2?.connected" class="alert alert-dark d-flex align-items-center" role="alert">
+              <Icon class="bi flex-shrink-0 me-2" name="solar:danger-triangle-bold" role="img" aria-label="Warning:" size="1.3rem" />
+              <div>Please <NuxtLink to="/app/connections">Connect your Spotify App</NuxtLink> before creating a reward</div>
+            </div>
+            <div class="d-grid">
+              <button type="submit" :class="`btn btn-lg ${webhook2 ? 'btn-danger' : 'btn-primary'} mt-2 rounded-4`" :disabled="loading || !service2?.connected">
+                <Transition name="slide" mode="out-in">
+                  <SpinnerCircle v-if="loading" />
+                  <span v-else>{{ webhook2 ? 'Delete reward' : 'Create reward' }}</span>
                 </Transition>
               </button>
             </div>

--- a/server/api/auth/twitch.get.ts
+++ b/server/api/auth/twitch.get.ts
@@ -1,7 +1,7 @@
 export default oauth.twitchEventHandler({
   config: {
     emailRequired: true,
-    scope: ["channel:manage:redemptions", "user:write:chat"]
+    scope: ["channel:manage:redemptions", "user:write:chat", "moderation:read"]
   },
   async onSuccess (event, result) {
     const user = result.user;

--- a/server/api/twitch/rewards/spotify-skip/index.delete.ts
+++ b/server/api/twitch/rewards/spotify-skip/index.delete.ts
@@ -1,0 +1,26 @@
+export default defineEventHandler(async (event) => {
+  const session = await requireUserSession(event);
+  const query = getQuery(event);
+  const config = useRuntimeConfig(event);
+
+  const twitchAPI = new Twitch({
+    client: config.oauth.twitch.clientId,
+    secret: config.oauth.twitch.clientSecret,
+    access_token: session.user.tokens.access_token
+  });
+
+  const accessResponse = await twitchAPI.getAppAccessToken();
+
+  if (!accessResponse) throw createError({ statusCode: ErrorCode.INTERNAL_SERVER_ERROR, message: "Failed to get app access token" });
+
+  if (Twitch.isAccessTokenExpired(session.user.tokens.expires_at)) {
+    await updateTwitchRefreshToken(event, twitchAPI, session.user);
+  }
+
+  if (!query.id_webhook || !query.id_reward) throw createError({ statusCode: ErrorCode.BAD_REQUEST, message: "Query parameters not valid" });
+
+  const deleteWebhook = await twitchAPI.deleteWebhook(query.id_webhook.toString());
+  const deleteRweward = await twitchAPI.deleteCustomReward(session.user.id, query.id_reward.toString());
+
+  return { success: deleteWebhook && deleteRweward };
+});

--- a/server/api/twitch/rewards/spotify-skip/index.get.ts
+++ b/server/api/twitch/rewards/spotify-skip/index.get.ts
@@ -1,0 +1,59 @@
+import { eq, and } from "drizzle-orm";
+
+export default defineEventHandler(async (event) => {
+  const session = await requireUserSession(event);
+  const config = useRuntimeConfig(event);
+  const output: { connected: boolean, rewards: Rewards[] } = { connected: false, rewards: [] };
+
+  const DB = useDB();
+  const connection = await DB.select({
+    type: tables.connections.type
+  }).from(tables.connections).where(and(eq(tables.connections.id_user, Number(session.user.id)), eq(tables.connections.type, "spotify"))).get();
+
+  if (!connection) return output;
+
+  output.connected = true;
+
+  const twitchAPI = new Twitch({
+    client: config.oauth.twitch.clientId,
+    secret: config.oauth.twitch.clientSecret,
+    access_token: session.user.tokens.access_token
+  });
+
+  const accessResponse = await twitchAPI.getAppAccessToken();
+  if (!accessResponse) throw createError({ statusCode: ErrorCode.INTERNAL_SERVER_ERROR, message: "An error occurred. Please try again." });
+
+  const twitchWebhooks = await twitchAPI.getWebhooks(session.user.id);
+  if (!twitchWebhooks.length) return output;
+
+  if (Twitch.isAccessTokenExpired(session.user.tokens.expires_at)) {
+    await updateTwitchRefreshToken(event, twitchAPI, session.user);
+  }
+
+  const rewards = await twitchAPI.getCustomRewards(session.user.id);
+
+  if (!rewards.length) return output;
+
+  output.rewards = twitchWebhooks.map((webhook) => {
+    const reward = rewards.find(reward => reward.id === webhook.condition.reward_id);
+    const isReward = webhook.transport.callback.includes("/api/webhooks/spotify-skip");
+    if (!reward || !isReward) return undefined;
+
+    return {
+      id: webhook.id,
+      transport: {
+        method: webhook.transport.method,
+        callback: webhook.transport.callback
+      },
+      reward: {
+        id: reward.id,
+        title: reward.title,
+        description: reward.prompt,
+        cost: reward.cost,
+        color: reward.background_color
+      }
+    };
+  }).filter(webhook => webhook !== undefined) as Rewards[];
+
+  return output;
+});

--- a/server/api/twitch/rewards/spotify-skip/index.post.ts
+++ b/server/api/twitch/rewards/spotify-skip/index.post.ts
@@ -30,7 +30,7 @@ export default defineEventHandler(async (event) => {
     webhook: "spotify-skip",
     broadcaster_id: session.user.id,
     reward_id: rewards.data[0].id,
-    secret: config.twitch.webhookSecret
+    secret: config.webhook.twitch.secretKey
   });
   if (!webhook) throw createError({ statusCode: ErrorCode.INTERNAL_SERVER_ERROR, message: "Failed to subscribe to reward webhook. Please try again." });
 

--- a/server/api/twitch/rewards/spotify-skip/index.post.ts
+++ b/server/api/twitch/rewards/spotify-skip/index.post.ts
@@ -19,7 +19,7 @@ export default defineEventHandler(async (event) => {
     description: body.description.toString(),
     cost: Number(body.cost),
     color: body.color?.toString(),
-    input_required: true
+    input_required: false
   });
   if (!rewards) throw createError({ statusCode: ErrorCode.BAD_REQUEST, message: "Failed to create reward" });
 
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event) => {
   if (!accessResponse) throw createError({ statusCode: ErrorCode.BAD_REQUEST, message: "Failed to get app access token" });
 
   const webhook = await twitchAPI.subscribeToWebhook({
-    webhook: "spotify-sr",
+    webhook: "spotify-skip",
     broadcaster_id: session.user.id,
     reward_id: rewards.data[0].id,
     secret: config.twitch.webhookSecret

--- a/server/api/twitch/rewards/spotify-sr/index.post.ts
+++ b/server/api/twitch/rewards/spotify-sr/index.post.ts
@@ -30,7 +30,7 @@ export default defineEventHandler(async (event) => {
     webhook: "spotify-sr",
     broadcaster_id: session.user.id,
     reward_id: rewards.data[0].id,
-    secret: config.twitch.webhookSecret
+    secret: config.webhook.twitch.secretKey
   });
   if (!webhook) throw createError({ statusCode: ErrorCode.INTERNAL_SERVER_ERROR, message: "Failed to subscribe to reward webhook. Please try again." });
 

--- a/server/api/webhooks/[reward].post.ts
+++ b/server/api/webhooks/[reward].post.ts
@@ -18,6 +18,8 @@ export default defineEventHandler(async (event) => {
     case "spotify-sr":
     case "twitch":
       return await rewardSpotifySR(event, body);
+    case "spotify-skip":
+      return await rewardSpotifySkip(event, body);
     default:
       return body;
   }

--- a/server/utils/rewards/spotify-skip.ts
+++ b/server/utils/rewards/spotify-skip.ts
@@ -48,13 +48,11 @@ export const rewardSpotifySkip = async (event: H3Event, body: TwitchWebhookPost)
 
   setResponseStatus(event, 204);
 
-  const moderators = await twitchAPI.getMods(webhookEvent.broadcaster_user_id, webhookEvent.user_id);
+  await spotifyAPI.skipToNext();
+  await twitchAPI.sendChatMessage(webhookEvent.broadcaster_user_id, `${webhookEvent.user_name} -> Executed skip to next song.`);
 
+  const moderators = await twitchAPI.getMods(webhookEvent.broadcaster_user_id, webhookEvent.user_id);
   if (moderators.some(data => data.user_id === webhookEvent.user_id)) {
-    await twitchAPI.sendChatMessage(webhookEvent.broadcaster_user_id, `${webhookEvent.user_name} -> Executed skip to next song.`);
     await twitchAPI.updateRedemption(webhookEvent.id, webhookEvent.broadcaster_user_id, webhookEvent.reward.id, "CANCELED");
-  }
-  else {
-    await twitchAPI.sendChatMessage(webhookEvent.broadcaster_user_id, `${webhookEvent.user_name} -> Executed skip to next song.`);
   }
 };

--- a/server/utils/rewards/spotify-skip.ts
+++ b/server/utils/rewards/spotify-skip.ts
@@ -1,0 +1,60 @@
+import { eq, sql } from "drizzle-orm";
+import type { H3Event } from "h3";
+
+export const rewardSpotifySkip = async (event: H3Event, body: TwitchWebhookPost) => {
+  const config = useRuntimeConfig(event);
+
+  const webhookEvent = body.event;
+
+  const DB = useDB();
+  const today = Date.now();
+
+  const connection = await DB.select({
+    client_id: tables.connections.client_id,
+    client_secret: tables.connections.client_secret,
+    refresh_token: tables.connections.refresh_token,
+    user_refresh_token: sql<string>`users.refresh_token`.as("user_refresh_token"),
+    language: tables.users.language
+  }).from(tables.connections).leftJoin(tables.users, eq(tables.connections.id_user, tables.users.id_user)).where(eq(tables.connections.id_user, Number(webhookEvent.broadcaster_user_id))).get();
+  if (!connection) throw createError({ statusCode: ErrorCode.NOT_FOUND, message: "No connection found" });
+
+  const spotifyAPI = new Spotify({
+    client: connection.client_id,
+    secret: connection.client_secret
+  });
+
+  const twitchAPI = new Twitch({
+    client: config.oauth.twitch.clientId,
+    secret: config.oauth.twitch.clientSecret
+  });
+
+  const spotifyTokens = await spotifyAPI.refreshToken(connection.refresh_token);
+  if (!spotifyTokens) throw createError({ statusCode: ErrorCode.BAD_REQUEST, message: "Failed to get Spotify access token" });
+  if (spotifyTokens.refresh_token !== connection.refresh_token) {
+    await DB.update(tables.users).set({
+      refresh_token: spotifyTokens.refresh_token,
+      updated_at: today
+    }).where(eq(tables.users.id_user, Number(webhookEvent.broadcaster_user_id))).run();
+  }
+
+  const twitchTokens = await twitchAPI.refreshToken(connection.user_refresh_token);
+  if (!twitchTokens) throw createError({ statusCode: ErrorCode.BAD_REQUEST, message: "Failed to get Twitch access token" });
+  if (twitchTokens.refresh_token !== connection.user_refresh_token) {
+    await DB.update(tables.users).set({
+      refresh_token: twitchTokens.refresh_token,
+      updated_at: today
+    }).where(eq(tables.users.id_user, Number(webhookEvent.broadcaster_user_id))).run();
+  }
+
+  setResponseStatus(event, 204);
+
+  const moderators = await twitchAPI.getMods(webhookEvent.broadcaster_user_id, webhookEvent.user_id);
+
+  if (moderators.some(data => data.user_id === webhookEvent.user_id)) {
+    await twitchAPI.sendChatMessage(webhookEvent.broadcaster_user_id, `${webhookEvent.user_name} -> Executed skip to next song.`);
+    await twitchAPI.updateRedemption(webhookEvent.id, webhookEvent.broadcaster_user_id, webhookEvent.reward.id, "CANCELED");
+  }
+  else {
+    await twitchAPI.sendChatMessage(webhookEvent.broadcaster_user_id, `${webhookEvent.user_name} -> Executed skip to next song.`);
+  }
+};

--- a/server/utils/spotify.ts
+++ b/server/utils/spotify.ts
@@ -103,6 +103,15 @@ class Spotify {
     }).catch(() => null);
     return response;
   }
+
+  async skipToNext () {
+    return await $fetch(`${baseURL}/me/player/next`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.access_token}`
+      }
+    }).then(() => true).catch(() => false);
+  }
 }
 
 export { Spotify };

--- a/server/utils/twitch.ts
+++ b/server/utils/twitch.ts
@@ -40,8 +40,8 @@ class Twitch {
     return response;
   }
 
-  async createCustomReward (options: { broadcaster_id: string, title: string, description: string, cost: number, color?: string }) {
-    const { broadcaster_id, title, description, cost, color } = options;
+  async createCustomReward (options: { broadcaster_id: string, title: string, description: string, cost: number, color?: string, input_required: boolean }) {
+    const { broadcaster_id, title, description, cost, color, input_required } = options;
     const response = await $fetch<TwitchRewardResponse>(`${baseURL}/channel_points/custom_rewards?broadcaster_id=${broadcaster_id}`, {
       method: "POST",
       headers: {
@@ -52,7 +52,7 @@ class Twitch {
         title,
         prompt: description,
         cost,
-        is_user_input_required: true,
+        is_user_input_required: input_required,
         background_color: color || "#1ED760"
       }
     }).catch(() => null);
@@ -154,6 +154,16 @@ class Twitch {
 
   static isAccessTokenExpired (expires_at: number) {
     return Date.now() >= expires_at;
+  }
+
+  async getMods (broadcaster_id: string, user_id: string) {
+    const mods = await $fetch<TwitchModsResponse>(`${baseURL}/mods?broadcaster_id=${broadcaster_id}&user_id=${user_id}`, {
+      headers: {
+        "client-id": this.client,
+        "Authorization": `Bearer ${this.access_token}`
+      }
+    }).catch(() => null);
+    return mods ? mods.data : [];
   }
 }
 

--- a/types/twitch.d.ts
+++ b/types/twitch.d.ts
@@ -94,6 +94,16 @@ declare global {
       cooldown_expires_at: number;
     }[];
   }
+  interface TwitchModsResponse {
+    data: {
+      user_id: string;
+      user_login: string;
+      user_name: string;
+    }[];
+    pagination: {
+      cursor: string;
+    };
+  }
 }
 
 export {};

--- a/utils/site.ts
+++ b/utils/site.ts
@@ -3,6 +3,6 @@ export const SITE = {
   url: {
     dev: "http://localhost:5173",
     prod: "https://plebrewards.yizack.com",
-    tunnel: "https://5hjnd7tc-5173.use2.devtunnels.ms"
+    tunnel: "" // replace with tunnel for local testing
   }
 };


### PR DESCRIPTION
Otros cambios específicos:
- Al crear un custom reward ahora se define el atributo `input_required` si el reward admite texto
- Se agregó el scope `moderation:read` para leer los moderadores de los canales de twitch

Para considerar:
- Verificar funcionamiento correcto (requerido)
- Mejorar la lógica de `pages/app/setup.vue` para eliminar código duplicado (lo dupliqué para no complicarme)
- Aclarar de alguna manera que los canjeos de skip to next song canjeado por moderadores les devuelve los puntos automáticamente (gratis) 

Closes #1